### PR TITLE
优化了三项

### DIFF
--- a/messenger.js
+++ b/messenger.js
@@ -23,7 +23,7 @@ window.Messenger = (function(){
     function Target(target, name, prefix){
         var errMsg = '';
         if(arguments.length < 2){
-            errMsg = 'target error - target and name are both requied';
+            errMsg = 'target error - target and name are both required';
         } else if (typeof target != 'object'){
             errMsg = 'target error - target itself must be window object';
         } else if (typeof name != 'string'){


### PR DESCRIPTION
1、优化：因为prefix是公用变量，如果同一个页面创建多个Messenger实例并且projectName不同时，会导致msg = msg.slice(prefix.length); 得到非预期结果。

2、优化：所有Messenger实例的generalCallback都绑定在 window.addEventListener('message',generalCallback); 当页面发生postMessage时，会把所有实例的generalCallback都执行一次，这里用projectName+messengerName 作为key并添加到要发送的msg前面作为区分回调函数。

3、优化：Messenger.prototype.listen 增加区分回调函数是否被重复被监听的功能。