### PR TITLE
通读源码后发现51行bug,ie6/ie7下也需要补齐消息前缀才能正常工作，否则与第90行代码矛盾

### DIFF
--- a/messenger.js
+++ b/messenger.js
@@ -48,7 +48,7 @@ window.Messenger = (function(){
         Target.prototype.send = function(msg){
             var targetFunc = window.navigator[this.prefix + this.name];
             if ( typeof targetFunc == 'function' ) {
-                targetFunc(this.prefix + msg, window);
+                targetFunc(this.prefix + '|' + this.name + '__Messenger__' + msg, window);
             } else {
                 throw new Error("target callback function is not defined");
             }
@@ -79,7 +79,7 @@ window.Messenger = (function(){
             if(typeof msg == 'object' && msg.data){
                 msg = msg.data;
             }
-            
+
             var msgPairs = msg.split('__Messenger__');
             var msg = msgPairs[1];
             var pairs = msgPairs[0].split('|');


### PR DESCRIPTION
通读源码后发现51行bug,ie6/ie7下也需要补齐消息前缀才能正常工作，否则与第90因为无法正确分离出前缀和名称，导致相关事件无法派发。经过win32虚拟机真实环境的ie6/7测试均通过，而未修改前则无法工作。