### PR TITLE
Expect msg.data to be a string

### DIFF
--- a/messenger.js
+++ b/messenger.js
@@ -76,7 +76,7 @@ window.Messenger = (function(){
     Messenger.prototype.initListen = function(){
         var self = this;
         var generalCallback = function(msg){
-            if(typeof msg == 'object' && msg.data){
+            if(typeof msg == 'object' && typeof msg.data === 'string'){
                 msg = msg.data;
             }
             


### PR DESCRIPTION
```js
msg.split('__Messenger__');
```

如果msg.data是空字符串，msg.split会报错